### PR TITLE
Runner image update

### DIFF
--- a/pytest-health/runner-image/Dockerfile
+++ b/pytest-health/runner-image/Dockerfile
@@ -1,31 +1,28 @@
-FROM python:3.12-slim AS compiler
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm AS compiler
+
 ENV PYTHONUNBUFFERED=1
-
-RUN python -m venv /venv
-ENV PATH="/venv/bin:$PATH"
-COPY ./utilities /utilities
-COPY ./runner-image/base_requirements.txt /requirements.txt
-RUN pip install -Ur /requirements.txt
-
-FROM python:3.12-slim AS runner
-
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    wget && \
-    # Clean up after installation
-    apt-get clean && rm -rf /var/lib/apt-get/lists/*
-
-COPY --from=compiler /venv /venv
-ENV PATH="/venv/bin:$PATH"
 
 WORKDIR /app
 
-COPY ./runner-image/run_script.sh /app/
-COPY ./runner-image/tests.py /app/
+COPY ./utilities /app/utilities
+COPY ./runner-image/base_requirements.txt /app/requirements.txt
 
-## Replace with a (preinstalled) set of packages
-COPY ./instrumentation/conftest.py /app/
+RUN uv venv && uv pip install -Ur requirements.txt
 
-RUN chmod +x /app/run_script.sh
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS runner
+
+COPY --from=compiler /app/.venv /app/.venv
+
+WORKDIR /app
+
+## TODO: Replace conftest with a (preinstalled) package
+COPY ./runner-image/run_script.sh ./runner-image/tests.py ./instrumentation/conftest.py /app/
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+    curl git && \
+    # Clean up after installation
+    apt-get clean && rm -rf /var/lib/apt-get/lists/* && \
+    chmod +x /app/run_script.sh
 
 ENTRYPOINT [ "/app/run_script.sh" ]
 

--- a/pytest-health/runner-image/base_requirements.txt
+++ b/pytest-health/runner-image/base_requirements.txt
@@ -1,4 +1,5 @@
 opentelemetry-exporter-otlp==1.25.0
+opensearch-py==2.8.0
 opentelemetry-instrumentation-requests==0.46b0
 opentelemetry-instrumentation==0.46b0
 pytest-custom-exit-code==0.3.0
@@ -6,4 +7,5 @@ pytest-xdist==3.6.1
 pytest==8.3.2
 requests==2.32.3
 opentelemetry-container-distro==0.2.0
+python-opentelemetry-access @ git+https://github.com/EOEPCA/python-opentelemetry-access.git@ab2a9b2b3d1b73e8d80c70c92ad535c7cf282fab
 ./utilities

--- a/pytest-health/runner-image/run_script.sh
+++ b/pytest-health/runner-image/run_script.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
-cd /app
-
-## TODO: Make optional by adding a default
-
 # Install requirements
 if [[ ! -z "$RESOURCE_HEALTH_RUNNER_REQUIREMENTS" ]]; then
-	pip3 install -r <(upcat "$RESOURCE_HEALTH_RUNNER_REQUIREMENTS")
+    uv run upcat "$RESOURCE_HEALTH_RUNNER_REQUIREMENTS" > requirements.txt
+	uv pip install -r requirements.txt
 fi
 
+uv run upcat "$RESOURCE_HEALTH_RUNNER_SCRIPT" > tests.py
+
 # Run tests
-opentelemetry-instrument --traces_exporter otlp --logs_exporter otlp "$@"
+uv run opentelemetry-instrument --traces_exporter otlp --logs_exporter otlp "$@"
 


### PR DESCRIPTION
Main changes:
+ Write the downloaded test script to file (instead of evaling it inside the script). The previous method causes pytest to produce confusing assertion error details
+ Replace wget by curl (one of the two is more or less necessary in order to send kill-command to sidecar containers, and curl is a bit more convenient)
+ Add python_opentelemetry_access as a default base requirement (used by our new example tests that read historical telemetry)
+ Use `uv` for faster startup