### PR TITLE
Add pre and post commands to runner image, and make the proxy check template use those

### DIFF
--- a/check_manager/src/check_backends/k8s_backend/template_utils/utils.py
+++ b/check_manager/src/check_backends/k8s_backend/template_utils/utils.py
@@ -43,7 +43,7 @@ from kubernetes_asyncio.client.models.v1_secret_key_selector import V1SecretKeyS
 
 DEFAULT_RUNNER_IMAGE: str = (
     os.environ.get("RH_CHECK_K8S_DEFAULT_RUNNER_IMAGE")
-    or "docker.io/eoepca/healthcheck_runner:2.0.0-rc1"
+    or "docker.io/eoepca/healthcheck_runner:v0.3.0-internal7-ccd84f1"
 )
 
 DEFAULT_OIDC_MITMPROXY_IMAGE: str = (

--- a/helm/templates/healthchecks-cronjobs.yaml
+++ b/helm/templates/healthchecks-cronjobs.yaml
@@ -56,9 +56,9 @@ spec:
                 user.id={{$check.userid}},
                 {{ end -}}
                 health_check.name={{$check.name}}
-            - name: RESOURCE_HEALTH_RUNNER_REQUIREMENTS
+            - name: RH_RUNNER_REQUIREMENTS
               value: {{ $check.requirements }}
-            - name: RESOURCE_HEALTH_RUNNER_SCRIPT
+            - name: RH_RUNNER_SCRIPT
               value: {{ $check.script }}
 
             volumeMounts:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -7,7 +7,7 @@ global:
   defaultHealthCheckImage:
     repository: docker.io/eoepca/healthcheck_runner
     pullPolicy: IfNotPresent
-    tag: "2.0.0-rc1"
+    tag: "v0.3.0-internal7-ccd84f1"
 
   ## TODO: Remove this default and make sure it is set or unused
   defaultOTLPEndpoint: https://resource-health-opentelemetry-collector:4317

--- a/pytest-health/runner-image/Dockerfile
+++ b/pytest-health/runner-image/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /app
 COPY ./runner-image/run_script.sh ./runner-image/tests.py ./instrumentation/conftest.py /app/
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    curl git && \
+    curl git netcat-traditional && \
     # Clean up after installation
     apt-get clean && rm -rf /var/lib/apt-get/lists/* && \
     chmod +x /app/run_script.sh

--- a/pytest-health/runner-image/Dockerfile
+++ b/pytest-health/runner-image/Dockerfile
@@ -11,6 +11,9 @@ RUN uv venv && uv pip install -Ur requirements.txt
 
 FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim AS runner
 
+ENV RH_RUNNER_RUN_BEFORE=
+ENV RH_RUNNER_RUN_AFTER=
+
 COPY --from=compiler /app/.venv /app/.venv
 
 WORKDIR /app
@@ -26,4 +29,4 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 
 ENTRYPOINT [ "/app/run_script.sh" ]
 
-CMD [ "pytest", "--export-traces", "--suppress-tests-failed-exit-code", "tests.py" ]
+CMD [ "pytest", "--export-traces", "--suppress-tests-failed-exit-code", "-rP", "tests.py" ]

--- a/pytest-health/runner-image/README.md
+++ b/pytest-health/runner-image/README.md
@@ -32,7 +32,7 @@ The image includes the OpenTelemety instrumentation for PyTest. If you have an O
 docker run --network host --rm --env RH_RUNNER_REQUIREMENTS="https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/requirements.txt" --env RH_RUNNER_SCRIPT="https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/test_arxiv_api.py" temporary_runner_image:v0.0.1
 ```
 
-It is currently published as `docker.io/eoepca/healthcheck_runner:2.0.0-rc1`.
+It is currently published as `docker.io/eoepca/healthcheck_runner:v0.3.0-internal7-ccd84f1`.
 
 ## Pre and post commands
 

--- a/pytest-health/runner-image/README.md
+++ b/pytest-health/runner-image/README.md
@@ -24,15 +24,21 @@ To test out a basic (non-instrumented) check run either serve the image locally 
 or use [this published test_arxiv_api.py](https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/test_arxiv_api.py) and [requirements.txt file](https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/requirements.txt).
 
 ```
-docker run --rm --env RESOURCE_HEALTH_RUNNER_REQUIREMENTS="https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/requirements.txt" --env RESOURCE_HEALTH_RUNNER_SCRIPT="https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/test_arxiv_api.py" temporary_runner_image:v0.0.1
+docker run --rm --env RH_RUNNER_REQUIREMENTS="https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/requirements.txt" --env RH_RUNNER_SCRIPT="https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/test_arxiv_api.py" temporary_runner_image:v0.0.1
 ```
 
 The image includes the OpenTelemety instrumentation for PyTest. If you have an OpenTelemetry endpoint accessible on the host machine you can, for example, run
 ```
-docker run --network host --rm --env RESOURCE_HEALTH_RUNNER_REQUIREMENTS="https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/requirements.txt" --env RESOURCE_HEALTH_RUNNER_SCRIPT="https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/test_arxiv_api.py" temporary_runner_image:v0.0.1
+docker run --network host --rm --env RH_RUNNER_REQUIREMENTS="https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/requirements.txt" --env RH_RUNNER_SCRIPT="https://raw.githubusercontent.com/EOEPCA/resource-health/a04ea5211fc60340656a20f45dcc0e9fa40eeee9/pytest-health/lib/other-examples/test_arxiv_api/test_arxiv_api.py" temporary_runner_image:v0.0.1
 ```
 
 It is currently published as `docker.io/eoepca/healthcheck_runner:2.0.0-rc1`.
+
+## Pre and post commands
+
+You can set environment variable `RH_RUNNER_RUN_BEFORE` when running the image to execute some command before running health checks.
+`RH_RUNNER_RUN_AFTER` is an analogous command to run after running health checks. Note that it will execute regardless if any of the previous commands fail.
+If any script command fails (including the before or after commands), the whole script will fail (i.e. have a non-zero exit code)
 
 # Notes
 

--- a/pytest-health/runner-image/run_script.sh
+++ b/pytest-health/runner-image/run_script.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 
-# Install requirements
-if [[ ! -z "$RESOURCE_HEALTH_RUNNER_REQUIREMENTS" ]]; then
-    uv run upcat "$RESOURCE_HEALTH_RUNNER_REQUIREMENTS" > requirements.txt
-	uv pip install -r requirements.txt
-fi
+# This structure is to ensure that $RH_RUNNER_RUN_AFTER is always executed at the end no matter what
+# and that if any command fails (including the $RH_RUNNER_RUN_AFTER), the whole script also fails
+(
+    eval "$RH_RUNNER_RUN_BEFORE" || exit $?
 
-uv run upcat "$RESOURCE_HEALTH_RUNNER_SCRIPT" > tests.py
+    # Install requirements
+    if [[ ! -z "$RH_RUNNER_REQUIREMENTS" ]]; then
+        uv run upcat "$RH_RUNNER_REQUIREMENTS" > requirements.txt || exit $?
+        uv pip install -r requirements.txt || exit $?
+    fi
 
-# Run tests
-uv run opentelemetry-instrument --traces_exporter otlp --logs_exporter otlp "$@"
+    uv run upcat "$RH_RUNNER_SCRIPT" > tests.py || exit $?
 
+    # Run tests
+    uv run opentelemetry-instrument --traces_exporter otlp --logs_exporter otlp "$@"
+)
+ret=$?
+eval "$RH_RUNNER_RUN_AFTER" || ret=$?;
+exit $ret


### PR DESCRIPTION
Make the health check runner scripts using proxy execute correctly by waiting for proxy to be set up before executing the health check script.